### PR TITLE
Resolve file path before saving

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import * as core from '@actions/core'
 import * as fs from 'fs'
+import * as path from 'path'
 
 async function run(): Promise<void> {
   try {
@@ -9,7 +10,8 @@ async function run(): Promise<void> {
     core.info(`Found filename: ${fileName}`)
     core.info(`Found json: ${json}`)
 
-    fs.writeFileSync(fileName, json)
+    const filePath = path.resolve(fileName)
+    fs.writeFileSync(filePath, json)
     core.info(`File written successfully`)
   } catch (error) {
     if (error instanceof Error) core.setFailed(error.message)


### PR DESCRIPTION
# Changes

In this PR I added path resolution for the `fileName` option. It allows, for example, writing files to a home directory (for example `~/file.json`).