### PR TITLE
Update to node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ inputs:
     required: true
     description: 'The filename you want to store the json in'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/main.js'


### PR DESCRIPTION
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: devops-actions/json-to-file@v1.0.3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.