### PR TITLE
fix: sync workflows with devops-actions/.github standards

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,13 @@
+﻿name: Lint GitHub Actions workflows
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  actionlint:
+    uses: devops-actions/.github/.github/workflows/actionlint.yml@main
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,4 +1,4 @@
-# Dependency Review Action
+﻿# Dependency Review Action
 #
 # This Action will scan dependency manifest files that change as part of a Pull Request,
 # surfacing known-vulnerable versions of the packages declared or updated in the PR.
@@ -11,17 +11,11 @@ on: [pull_request]
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
-      - name: 'Checkout Repository'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: 'Dependency Review'
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+    uses: devops-actions/.github/.github/workflows/dependency-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write


### PR DESCRIPTION
Sync workflows with the devops-actions/.github shared workflow standards:

- **dependency-review.yml**: replaced standalone workflow with the standard caller pattern pointing to \devops-actions/.github\
- **actionlint.yml**: added missing caller for the shared actionlint reusable workflow
- **scorecards.yml**: removed duplicate standalone OSSF scorecard workflow (\ossf-analysis.yml\ already covers this via \w-ossf-scorecard.yml\)