### PR TITLE
Upgrade action runtime and CI from Node 20 to Node 24

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -31,10 +31,10 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set Node.js 20.x
+      - name: Set Node.js 24.x
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 20.x
+          node-version: 24.x
 
       - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:

--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ inputs:
     required: true
     description: 'The filename you want to store the json in'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/main.js'


### PR DESCRIPTION
Fixes #439

Node 20 is deprecated. This PR upgrades the action runtime and CI workflow to Node 24.

## Changes
- `action.yml`: `using: 'node20'` → `using: 'node24'`
- `.github/workflows/check-dist.yml`: Node version `20.x` → `24.x`

No source code changes required — the `dist/` output is identical.