### PR TITLE
fix: pin reusable workflow refs to SHA to resolve pinned-dependency alerts

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   actionlint:
-    uses: devops-actions/.github/.github/workflows/actionlint.yml@main
+    uses: devops-actions/.github/.github/workflows/actionlint.yml@686cfb7424be0c32c8fe4e9e335f4500c5e9978c # main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/actions-example-checker.yml
+++ b/.github/workflows/actions-example-checker.yml
@@ -7,6 +7,6 @@ permissions:
 
 jobs:
   validate-examples:
-    uses: devops-actions/.github/.github/workflows/actions-example-checker.yml@main
+    uses: devops-actions/.github/.github/workflows/actions-example-checker.yml@686cfb7424be0c32c8fe4e9e335f4500c5e9978c # main
     permissions:
       contents: read

--- a/.github/workflows/approve-dependabot-pr.yml
+++ b/.github/workflows/approve-dependabot-pr.yml
@@ -11,6 +11,6 @@ jobs:
       contents: write
       pull-requests: write
       actions: write
-    uses: devops-actions/.github/.github/workflows/approve-dependabot-pr.yml@main
+    uses: devops-actions/.github/.github/workflows/approve-dependabot-pr.yml@686cfb7424be0c32c8fe4e9e335f4500c5e9978c # main
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   dependency-review:
-    uses: devops-actions/.github/.github/workflows/dependency-review.yml@main
+    uses: devops-actions/.github/.github/workflows/dependency-review.yml@686cfb7424be0c32c8fe4e9e335f4500c5e9978c # main
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary

Resolves the open **Pinned-Dependencies** code scanning alerts (#45, #46, #48, #49).

All four reusable workflow calls were referencing \devops-actions/.github\ workflows using the mutable \@main\ ref. This has been updated to pin to the current SHA \686cfb7424be0c32c8fe4e9e335f4500c5e9978c\ (with \# main\ comment for readability).

## Changed files
- \.github/workflows/dependency-review.yml\
- \.github/workflows/actionlint.yml\
- \.github/workflows/actions-example-checker.yml\
- \.github/workflows/approve-dependabot-pr.yml\

## Alerts addressed
| Alert | File |
|-------|------|
| #49 | dependency-review.yml |
| #48 | actionlint.yml |
| #46 | actions-example-checker.yml |
| #45 | approve-dependabot-pr.yml |
