### PR TITLE
fix: quote variable in check-dist.yml to resolve shellcheck SC2086

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -64,7 +64,7 @@ jobs:
  
             git add dist/*
             git commit -m "Update dist"
-            git push origin HEAD:${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}
+            git push origin "HEAD:${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
           fi
 
       - name: Compare the expected and actual dist/ directories


### PR DESCRIPTION
## Summary

Fixes a pre-existing shellcheck SC2086 warning in `.github/workflows/check-dist.yml` that was blocking actionlint checks.

### Change

Double-quote the `git push` refspec variable expansion to prevent globbing and word splitting:

```diff
- git push origin HEAD:${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}
+ git push origin "HEAD:${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
```

### Background

The `actionlint / run-actionlint` check flagged this with:
```
SC2086:info:11:24: Double quote to prevent globbing and word splitting
```

This is unrelated to any functional change — just adds proper quoting per shellcheck best practices.